### PR TITLE
Interact with Country as an Object

### DIFF
--- a/src/Guide.php
+++ b/src/Guide.php
@@ -13,6 +13,16 @@ class Guide
     private $config;
 
     /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @var string
+     */
+    public $abbreviation;
+
+    /**
      * Guide constructor.
      * @param Repository $config
      */
@@ -27,9 +37,10 @@ class Guide
      */
     public function name(string $abbreviation)
     {
-        $abbreviation = strtoupper($abbreviation);
+        $this->abbreviation = strtoupper($abbreviation);
+        $this->name = Arr::get($this->config->get('countries'), $this->abbreviation);
 
-        return Arr::get($this->config->get('countries'), $abbreviation);
+        return $this;
     }
 
     /**
@@ -41,11 +52,15 @@ class Guide
         $countries = $this->config->get('countries');
         $found = $this->scanStringNames($name, $countries);
 
+        $this->name = $name;
+
         if ($found) {
-            return $found;
+            $this->abbreviation = $found;
         } else {
-            return $this->scanArrayNames($name, $countries);
+            $this->abbreviation = $this->scanArrayNames($name, $countries);
         }
+
+        return $this;
     }
 
     /**

--- a/tests/CountryTest.php
+++ b/tests/CountryTest.php
@@ -14,4 +14,22 @@ class CountryTest extends TestCase {
         $country = (new Guide($this->config))->name('LB');
         $this->assertEquals('Lebanon', $country->name);
     }
+
+    public function test_country_has_abbreviation()
+    {
+        $country = (new Guide($this->config))->name('LB');
+        $this->assertEquals('LB', $country->abbreviation);
+    }
+
+    public function test_abbreviation_method_returns_county_object()
+    {
+        $country = (new Guide($this->config))->abbreviation('Lebanon');
+        $this->assertEquals('LB', $country->abbreviation);
+        $this->assertEquals('Lebanon', $country->name);
+    }
+
+    public function test_it_returns_first_country_name_if_the_name_is_array(){
+        $country = (new Guide($this->config))->name('AE');
+        $this->assertEquals(['UAE', 'United Arab Emirates'], $country->name);
+    }
 }

--- a/tests/CountryTest.php
+++ b/tests/CountryTest.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Vinelab\Country\Tests;
+
+
+use Vinelab\Country\Facades\Country;
+use Vinelab\Country\Guide;
+
+class CountryTest extends TestCase {
+
+    public function test_country_has_name()
+    {
+        $country = (new Guide($this->config))->name('LB');
+        $this->assertEquals('Lebanon', $country->name);
+    }
+}

--- a/tests/GuideTest.php
+++ b/tests/GuideTest.php
@@ -8,20 +8,20 @@ class GuideTest extends TestCase
 
     public function test_get_country_abbreviation_from_string_name()
     {
-        $guide = new Guide($this->config);
-        $this->assertEquals('LB', $guide->abbreviation('Lebanon'));
+        $guide = (new Guide($this->config))->abbreviation('Lebanon');
+        $this->assertEquals('LB', $guide->abbreviation);
     }
 
     public function test_get_country_abbreviation_from_array_name()
     {
-        $guide = new Guide($this->config);
-        $this->assertEquals('AE', $guide->abbreviation('United Arab Emirates'));
+        $guide = (new Guide($this->config))->abbreviation('United Arab Emirates');
+        $this->assertEquals('AE', $guide->abbreviation);
     }
 
     public function test_get_country_name_from_abbreviation()
     {
-        $guide = new Guide($this->config);
-        $this->assertEquals(['UAE', 'United Arab Emirates'], $guide->name('AE'));
+        $guide = (new Guide($this->config))->name('AE');
+        $this->assertEquals(['UAE', 'United Arab Emirates'], $guide->name);
     }
 
     public function test_get_all_countries()

--- a/tests/GuideTest.php
+++ b/tests/GuideTest.php
@@ -1,31 +1,10 @@
 <?php
 
 namespace Vinelab\Country\Tests;
-
-use Illuminate\Contracts\Config\Repository;
-use Mockery;
-use PHPUnit\Framework\TestCase;
 use Vinelab\Country\Guide;
 
 class GuideTest extends TestCase
 {
-    /**
-     * @var array
-     */
-    protected $countries;
-
-    /**
-     * @var Repository|Mockery\MockInterface
-     */
-    private $config;
-
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $this->countries = require __DIR__.'/../config/countries.php';
-        $this->config = $this->getMockedConfig($this->countries);
-    }
 
     public function test_get_country_abbreviation_from_string_name()
     {
@@ -51,17 +30,5 @@ class GuideTest extends TestCase
         $this->assertEquals($this->countries, $guide->all());
     }
 
-    /**
-     * @param array $countries
-     * @return Repository|Mockery\MockInterface
-     */
-    protected function getMockedConfig(array $countries)
-    {
-        $mConfig = Mockery::mock(Repository::class);
-        $mConfig->shouldReceive('get')->once()
-            ->with('countries')
-            ->andReturn($countries);
 
-        return $mConfig;
-    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,42 @@
+<?php
+
+
+namespace Vinelab\Country\Tests;
+use Illuminate\Contracts\Config\Repository;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+use Mockery;
+class TestCase extends BaseTestCase{
+
+    /**
+     * @var array
+     */
+    protected $countries;
+
+    /**
+     * @var Repository|Mockery\MockInterface
+     */
+    protected $config;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->countries = require __DIR__.'/../config/countries.php';
+        $this->config = $this->getMockedConfig($this->countries);
+    }
+
+    /**
+     * @param array $countries
+     * @return Repository|Mockery\MockInterface
+     */
+    protected function getMockedConfig(array $countries)
+    {
+        $mConfig = Mockery::mock(Repository::class);
+        $mConfig->shouldReceive('get')->once()
+            ->with('countries')
+            ->andReturn($countries);
+
+        return $mConfig;
+    }
+
+}


### PR DESCRIPTION
PR changes:

- Refactor the testing setup to make it simple.
- Add (name and abbreviation attributes) to interact with a country as an object not string.